### PR TITLE
feat: add label synchronization workflow and define labels

### DIFF
--- a/.github/labels.yaml
+++ b/.github/labels.yaml
@@ -1,0 +1,35 @@
+- name: 'comp: frontend'
+  color: '4DA2B0'
+  description: 'Client-side UI, CSS'
+
+- name: 'comp: backend'
+  color: '23A66F'
+  description: 'Server-side logic and APIs'
+
+- name: 'comp: infra'
+  color: '875318'
+  description: 'DevOps, Terraform, Vault policies'
+
+- name: 'comp: database'
+  color: 'A5A378'
+  description: 'Schema changes, queries, migrations'
+
+- name: 'comp: dependencies'
+  color: 'EE042A'
+  description: 'Package updates, third-party libraries'
+
+- name: 'status: blocked'
+  color: '000000'
+  description: 'Cannot proceed (waiting on an API key, support, etc.)'
+
+- name: 'status: needs-info'
+  color: '5319E7'
+  description: 'Waiting for clarification before work can start'
+
+- name: 'triage: duplicate'
+  color: 'CFD3D7'
+  description: 'This issue already exists elsewhere'
+
+- name: 'triage: wontfix'
+  color: 'FFFFFF'
+  description: 'Invalid, out of scope, or intentionally ignored'

--- a/.github/workflows/sync-labels.yaml
+++ b/.github/workflows/sync-labels.yaml
@@ -1,0 +1,41 @@
+name: Sync Organization Labels
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/labels.yaml'
+
+jobs:
+  sync_labels:
+    runs-on: ubuntu-latest
+    strategy:
+      # fail-fast: false ensures that if one repo fails (e.g., typo in the name),
+      # the workflow continues to sync the remaining repositories.
+      fail-fast: false
+      matrix:
+        repository:
+          - Bfloo-App/web-client-dashboard
+          - Bfloo-App/website
+          - Bfloo-App/databases
+          - Bfloo-App/platform-infra
+          - Bfloo-App/ai-assistant-api
+          - Bfloo-App/bfloo
+          - Bfloo-App/database-schema-spec
+          - Bfloo-App/platform-vault
+          - Bfloo-App/.github
+
+    steps:
+      - name: Checkout Central Repository
+        uses: actions/checkout@v6.0.2
+
+      - name: Sync Labels to ${{ matrix.repository }}
+        uses: EndBug/label-sync@v2.3.3
+        env:
+          GITHUB_REPOSITORY: ${{ matrix.repository }}
+
+        with:
+          config-file: .github/labels.yaml
+          token: ${{ secrets.LABEL_SYNC_TOKEN }}
+          delete-other-labels: true


### PR DESCRIPTION
This pull request introduces a standardized system for managing GitHub labels across multiple repositories and automates their synchronization. The main changes include defining a unified set of labels in a central configuration file and adding a GitHub Actions workflow to sync these labels to all relevant repositories.

Label standardization:

* Added a new `.github/labels.yaml` file that defines consistent component, status, and triage labels (e.g., `comp: frontend`, `status: blocked`) with colors and descriptions for use across all repositories.

Label synchronization automation:

* Added a new workflow `.github/workflows/sync-labels.yaml` that automatically syncs the labels defined in `.github/labels.yaml` to a list of specified repositories whenever changes are pushed to the `main` branch.
* The workflow uses the `EndBug/label-sync` GitHub Action to apply label changes and ensures that labels not present in the config are deleted from each repository, keeping label sets consistent.