### PR TITLE
feat: enable manual triggering of label synchronization workflow

### DIFF
--- a/.github/workflows/sync-labels.yaml
+++ b/.github/workflows/sync-labels.yaml
@@ -7,6 +7,8 @@ on:
     paths:
       - '.github/labels.yaml'
 
+  workflow_dispatch:
+
 jobs:
   sync_labels:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request makes a small update to the GitHub Actions workflow configuration, allowing the `sync-labels.yaml` workflow to be triggered manually using the "workflow_dispatch" event.