### PR TITLE
feat: remove optional target release field from user story templateRemove optional target release field from user story template

### DIFF
--- a/.github/ISSUE_TEMPLATE/user-story.yaml
+++ b/.github/ISSUE_TEMPLATE/user-story.yaml
@@ -33,15 +33,6 @@ body:
     validations:
       required: true
 
-  - type: input
-    id: target-release
-    attributes:
-      label: 🎯 Target Release (Optional)
-      description: 'Which major milestone or product launch does this belong to?'
-      placeholder: 'e.g., MVP App Launch, Q3 Authentication Overhaul'
-    validations:
-      required: false
-
   - type: textarea
     id: technical-notes
     attributes:


### PR DESCRIPTION
Eliminate the optional target release field from the user story template to streamline the input process.